### PR TITLE
Enhance iii-cli update functionality and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,20 @@ Output example:
 
 ### Update Binaries
 
-Update all installed binaries to their latest versions:
+Update iii-cli and all installed binaries to their latest versions:
 
 ```bash
 iii-cli update
 ```
 
-Update a specific binary:
+Update only iii-cli itself:
+
+```bash
+iii-cli update self
+iii-cli update iii-cli
+```
+
+Update a specific managed binary:
 
 ```bash
 iii-cli update console

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
     name = "iii-cli",
     about = "Unified CLI dispatcher for iii tools",
     version,
-    after_help = "COMMANDS:\n  console    Launch the iii web console\n  create     Create a new iii project from a template\n  motia      Create a new Motia project from a template\n  start      Start the iii process communication engine\n  update     Update managed binaries to their latest versions\n  list       Show installed binaries and their versions"
+    after_help = "COMMANDS:\n  console    Launch the iii web console\n  create     Create a new iii project from a template\n  motia      Create a new Motia project from a template\n  start      Start the iii process communication engine\n  update     Update iii-cli and managed binaries to their latest versions\n  list       Show installed binaries and their versions\n\nSELF-UPDATE:\n  iii-cli update              Update iii-cli + all managed binaries\n  iii-cli update self         Update only iii-cli\n  iii-cli update iii-cli      Update only iii-cli\n  iii-cli update console      Update only iii-console"
 )]
 pub struct Cli {
     /// Disable background update and advisory checks
@@ -62,10 +62,11 @@ pub enum Commands {
         args: Vec<String>,
     },
 
-    /// Update managed binaries to their latest versions
+    /// Update iii-cli and managed binaries to their latest versions
     Update {
-        /// Specific command or binary to update (e.g., "console", "create").
-        /// If omitted, updates all installed binaries.
+        /// Specific command or binary to update (e.g., "console", "self").
+        /// Use "self" or "iii-cli" to update only iii-cli.
+        /// If omitted, updates iii-cli and all installed binaries.
         #[arg(name = "command")]
         target: Option<String>,
     },

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,6 +24,24 @@ pub struct CommandMapping {
     pub binary_subcommand: Option<&'static str>,
 }
 
+/// Specification for iii-cli itself (the dispatcher).
+/// Kept separate from REGISTRY because iii-cli is not a dispatched binary.
+pub static SELF_SPEC: BinarySpec = BinarySpec {
+    name: "iii-cli",
+    repo: "iii-hq/iii-cli",
+    has_checksum: true,
+    supported_targets: &[
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-msvc",
+        "aarch64-pc-windows-msvc",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
+        "aarch64-unknown-linux-gnu",
+    ],
+    commands: &[],
+};
+
 /// The compiled-in binary registry
 pub static REGISTRY: &[BinarySpec] = &[
     BinarySpec {
@@ -224,6 +242,39 @@ mod tests {
     fn test_console_has_checksum() {
         let (spec, _) = resolve_command("console").unwrap();
         assert!(spec.has_checksum);
+    }
+
+    #[test]
+    fn test_self_spec_fields() {
+        assert_eq!(SELF_SPEC.name, "iii-cli");
+        assert_eq!(SELF_SPEC.repo, "iii-hq/iii-cli");
+        assert!(SELF_SPEC.has_checksum);
+        assert!(SELF_SPEC.commands.is_empty());
+    }
+
+    #[test]
+    fn test_self_spec_supported_targets() {
+        assert!(SELF_SPEC.supported_targets.contains(&"aarch64-apple-darwin"));
+        assert!(SELF_SPEC.supported_targets.contains(&"x86_64-apple-darwin"));
+        assert!(SELF_SPEC.supported_targets.contains(&"x86_64-unknown-linux-gnu"));
+        assert!(SELF_SPEC.supported_targets.contains(&"x86_64-unknown-linux-musl"));
+        assert!(SELF_SPEC.supported_targets.contains(&"aarch64-unknown-linux-gnu"));
+        assert!(SELF_SPEC.supported_targets.contains(&"x86_64-pc-windows-msvc"));
+        assert!(SELF_SPEC.supported_targets.contains(&"aarch64-pc-windows-msvc"));
+        assert_eq!(SELF_SPEC.supported_targets.len(), 7);
+    }
+
+    #[test]
+    fn test_self_spec_not_in_registry() {
+        for spec in REGISTRY {
+            assert_ne!(spec.name, "iii-cli", "iii-cli should not be in REGISTRY");
+        }
+    }
+
+    #[test]
+    fn test_self_spec_platform_support() {
+        let result = crate::platform::check_platform_support(&SELF_SPEC);
+        assert!(result.is_ok());
     }
 
 }


### PR DESCRIPTION
## Summary

- Add explicit self-update support via `iii-cli update self` and `iii-cli update iii-cli`.
- Include `iii-cli` in `update_all` so `iii-cli update` refreshes the dispatcher first, then managed binaries.
- Improve update UX/docs with clearer command help and a restart note after successful self-update.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] Changes are scoped to the intended feature.
- [x] Documentation/help text was updated to reflect new behavior.
- [x] Unit tests pass locally (`cargo test`).
- [ ] Additional integration/e2e validation was performed.

## Additional Context

- The repository does not contain a `develop` branch, so this PR targets `main`.
- Self-update uses a dedicated `SELF_SPEC` in `registry` to avoid mixing dispatcher metadata with dispatched binary mappings.
