### PR TITLE
Disable help flag on passthrough commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ pub enum Commands {
     #[command(
         trailing_var_arg = true,
         allow_hyphen_values = true,
+        disable_help_flag = true,
     )]
     Console {
         /// Arguments passed through to the binary
@@ -33,6 +34,7 @@ pub enum Commands {
     #[command(
         trailing_var_arg = true,
         allow_hyphen_values = true,
+        disable_help_flag = true,
     )]
     Create {
         /// Arguments passed through to the binary
@@ -44,6 +46,7 @@ pub enum Commands {
     #[command(
         trailing_var_arg = true,
         allow_hyphen_values = true,
+        disable_help_flag = true,
     )]
     Motia {
         /// Arguments passed through to the binary
@@ -55,6 +58,7 @@ pub enum Commands {
     #[command(
         trailing_var_arg = true,
         allow_hyphen_values = true,
+        disable_help_flag = true,
     )]
     Start {
         /// Arguments passed through to the binary


### PR DESCRIPTION
## Summary
- Disable Clap's automatic `-h/--help` handling for passthrough subcommands (`console`, `create`, `motia`, `start`).
- Prevent the wrapper CLI from intercepting help flags that should be forwarded to downstream binaries.
- Keep existing passthrough behavior (`trailing_var_arg` + `allow_hyphen_values`) while improving command compatibility.

## Test plan
- [x] Review `git diff main...HEAD` to confirm only `src/cli.rs` changed.
- [ ] Run `iii-cli console --help` and verify help is provided by downstream target.
- [ ] Run `iii-cli create --help` and verify passthrough behavior remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted help flag handling behavior for Console, Create, Motia, and Start subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->