### PR TITLE
fix: correct update/install detection and self-update version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "iii-cli"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | bash -s -- -v 0.1.0
 
 Custom directory:
 ```bash
-INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/iii-hq/iii-cli/main/install.sh | bash
+curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | INSTALL_DIR=/usr/local/bin bash
 ```
 
 The script auto-detects your platform, downloads the correct binary, verifies the SHA256 checksum, and adds it to your `PATH`.

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ EXAMPLES:
     curl -fsSL https://raw.githubusercontent.com/iii-hq/iii-cli/main/install.sh | bash -s -- -v 0.1.3
 
     # Install to custom directory
-    INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/iii-hq/iii-cli/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/iii-hq/iii-cli/main/install.sh | INSTALL_DIR=/usr/local/bin bash
 
     # Install from local binary
     ./install.sh -b ./target/release/iii-cli

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
     name = "iii-cli",
     about = "Unified CLI dispatcher for iii tools",
     version,
-    after_help = "COMMANDS:\n  console    Launch the iii web console\n  create     Create a new iii project from a template\n  motia      Create a new Motia project from a template\n  start      Start the iii process communication engine\n  update     Update iii-cli and managed binaries to their latest versions\n  list       Show installed binaries and their versions\n\nSELF-UPDATE:\n  iii-cli update              Update iii-cli + all managed binaries\n  iii-cli update self         Update only iii-cli\n  iii-cli update iii-cli      Update only iii-cli\n  iii-cli update console      Update only iii-console"
+    after_help = "COMMANDS:\n  console    Launch the iii web console\n  create     Create a new iii project from a template\n  motia      Create a new Motia project from a template\n  start      Start the iii process communication engine\n  update     Update iii-cli and managed binaries to their latest versions\n  list       Show installed binaries and their versions\n\n"
 )]
 pub struct Cli {
     /// Disable background update and advisory checks


### PR DESCRIPTION
## Summary

- Fixes update behavior so binaries missing on disk are treated as installs, avoiding false "already up to date" results from stale state.
- Improves self-update version detection by preferring installed state over compile-time version, preventing unnecessary re-downloads in dev builds.
- Aligns install command examples/help text and bumps CLI version metadata.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal cleanup

## Checklist

- [x] I have reviewed my own code changes.
- [x] I have tested the change locally.
- [x] I have considered backward compatibility.
- [x] I have updated relevant documentation/help text.

## Additional Context

This change focuses on update correctness when local binary state is out-of-sync with files on disk, and on preventing redundant downloads during self-update flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation command format and source URL in setup instructions.

* **Bug Fixes**
  * Improved update mechanism to accurately distinguish between installing new binaries and updating existing ones.
  * Enhanced version tracking for precise update status reporting.

* **Chores**
  * Simplified help text output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->