### PR TITLE
nit: specific version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | bash
 
 Specific version:
 ```bash
-curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | bash -s -- -v 0.1.0
+curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | bash -s -- -v VERSION_NUMBER
 ```
 
 Custom directory:


### PR DESCRIPTION
0.1.0 doesn't exist so it fails, we also don't want to encourage users to install old versions so I left a placeholder. If they copy the placeholder and try it they'll get the informative error message:

error: invalid version format: latest (expected: X.Y.Z or X.Y.Z-pre)