### PR TITLE
chore: update installation script and CLI commands; bump version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "iii-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 REPO="${REPO:-iii-hq/iii-cli}"
 BIN_NAME="${BIN_NAME:-iii-cli}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+BREW_FORMULA="${BREW_FORMULA:-$BIN_NAME}"
 
 # Validate REPO format (owner/repo)
 if [[ ! "$REPO" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
@@ -38,6 +39,12 @@ fi
 # Validate INSTALL_DIR contains only safe path characters
 if [[ "$INSTALL_DIR" =~ [^a-zA-Z0-9/_.~:@+-] ]]; then
   echo "error: INSTALL_DIR contains invalid characters" >&2
+  exit 1
+fi
+
+# Validate BREW_FORMULA (allow tap notation like org/tap/formula and @ for versioned formulae)
+if [[ ! "$BREW_FORMULA" =~ ^[a-zA-Z0-9_@/.-]+$ ]]; then
+  echo "error: BREW_FORMULA contains invalid characters (got: $BREW_FORMULA)" >&2
   exit 1
 fi
 
@@ -70,6 +77,36 @@ print_message() {
   printf "${color}%s${NC}\n" "$message"
 }
 
+check_homebrew() {
+  # Skip if --force was used
+  if [[ "$force_install" == "true" ]]; then
+    return 0
+  fi
+
+  # Only check if brew is available on the system
+  if ! command -v brew >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Check if the formula is installed via Homebrew
+  if brew list --versions "$BREW_FORMULA" >/dev/null 2>&1; then
+    local brew_version
+    brew_version=$(brew list --versions "$BREW_FORMULA" | awk '{print $NF}')
+
+    printf "\n"
+    printf "${ORANGE}%s is installed via Homebrew${NC}" "$BREW_FORMULA"
+    if [[ -n "$brew_version" ]]; then
+      printf " ${MUTED}(v%s)${NC}" "$brew_version"
+    fi
+    printf "\n\n"
+    printf "${MUTED}Choose one:${NC}\n"
+    printf "  ${NC}1. Update via Homebrew:  ${ORANGE}brew upgrade %s${NC}\n" "$BREW_FORMULA"
+    printf "  ${NC}2. Switch to manual:    ${ORANGE}brew uninstall --force %s${NC} then re-run this script\n" "$BREW_FORMULA"
+    printf "\n"
+    exit 1
+  fi
+}
+
 # --- Usage / help -------------------------------------------------------------
 
 usage() {
@@ -86,6 +123,7 @@ OPTIONS:
     -v, --version <version>     Install a specific version (e.g. 0.1.3)
     -b, --binary <path>         Install from a local binary instead of downloading
     --no-modify-path            Skip adding the install directory to PATH
+    --force                     Skip Homebrew conflict check
 
 ENVIRONMENT VARIABLES:
     REPO            GitHub repository          (default: iii-hq/iii-cli)
@@ -93,6 +131,7 @@ ENVIRONMENT VARIABLES:
     INSTALL_DIR     Installation directory      (default: \$HOME/.local/bin)
     TARGET          Override platform target    (e.g. aarch64-apple-darwin)
     VERSION         Version to install          (same as -v/--version)
+    BREW_FORMULA    Homebrew formula name       (default: \$BIN_NAME)
 
 EXAMPLES:
     # Install latest version
@@ -115,6 +154,7 @@ EOF
 requested_version="${VERSION:-}"
 no_modify_path=false
 binary_path=""
+force_install=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -137,6 +177,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-modify-path)
       no_modify_path=true
+      shift
+      ;;
+    --force)
+      force_install=true
       shift
       ;;
     -*)
@@ -180,8 +224,14 @@ check_version() {
     installed_version="${installed_version#v}"
 
     if [[ -n "$installed_version" ]]; then
+      local existing_path
+      existing_path=$(command -v "$BIN_NAME" 2>/dev/null || echo "")
       if [[ "$installed_version" == "$target_version" ]]; then
-        printf "${MUTED}Version ${NC}%s${MUTED} already installed${NC}\n" "$target_version"
+        printf "${MUTED}Version ${NC}%s${MUTED} already installed at ${NC}%s\n" "$target_version" "$existing_path"
+        if [[ -n "$existing_path" && "$(dirname "$existing_path")" != "$INSTALL_DIR" ]]; then
+          printf "${MUTED}To install to ${NC}%s${MUTED}, first remove the existing binary:${NC}\n" "$INSTALL_DIR"
+          printf "  rm %s\n" "$existing_path"
+        fi
         exit 0
       else
         printf "${MUTED}Installed version: ${NC}%s${MUTED}. Upgrading...${NC}\n" "$installed_version"
@@ -309,6 +359,9 @@ asset_url=""
 # --- Platform detection & release fetching (skip if --binary) -----------------
 
 if [[ -z "$binary_path" ]]; then
+
+  # Check for Homebrew-managed installation before any network calls
+  check_homebrew
 
   # --- Platform detection -----------------------------------------------------
 
@@ -701,7 +754,7 @@ if [[ -x "$INSTALL_DIR/$BIN_NAME" ]]; then
   printf "\n"
   printf "  iii-cli console          ${MUTED}# Launch iii-console${NC}\n"
   printf "  iii-cli create           ${MUTED}# Create new project${NC}\n"
-  printf "  iii-cli motia            ${MUTED}# Run motia CLI${NC}\n"
+  printf "  iii-cli sdk motia        ${MUTED}# Run motia CLI${NC}\n"
   printf "  iii-cli --help           ${MUTED}# See all commands${NC}\n"
   printf "\n"
   printf "${MUTED}Installed to: ${NC}%s/%s\n" "$INSTALL_DIR" "$BIN_NAME"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,6 @@ use clap::{Parser, Subcommand};
     name = "iii-cli",
     about = "Unified CLI dispatcher for iii tools",
     version,
-    after_help = "COMMANDS:\n  console    Launch the iii web console\n  create     Create a new iii project from a template\n  motia      Create a new Motia project from a template\n  start      Start the iii process communication engine\n  update     Update iii-cli and managed binaries to their latest versions\n  list       Show installed binaries and their versions\n\n"
 )]
 pub struct Cli {
     /// Disable background update and advisory checks
@@ -42,17 +41,9 @@ pub enum Commands {
         args: Vec<String>,
     },
 
-    /// Create a new Motia project from a template
-    #[command(
-        trailing_var_arg = true,
-        allow_hyphen_values = true,
-        disable_help_flag = true,
-    )]
-    Motia {
-        /// Arguments passed through to the binary
-        #[arg(num_args = 0..)]
-        args: Vec<String>,
-    },
+    /// Manage SDKs powered by Motia
+    #[command(subcommand)]
+    Sdk(SdkCommands),
 
     /// Start the iii process communication engine
     #[command(
@@ -79,6 +70,22 @@ pub enum Commands {
     List,
 }
 
+/// SDK subcommands
+#[derive(Subcommand)]
+pub enum SdkCommands {
+    /// Motia SDK tools
+    #[command(
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        disable_help_flag = true,
+    )]
+    Motia {
+        /// Arguments passed through to the binary
+        #[arg(num_args = 0..)]
+        args: Vec<String>,
+    },
+}
+
 /// Extract the command name and passthrough args from a parsed Commands value.
 pub fn extract_command_info(cmd: &Commands) -> CommandInfo<'_> {
     match cmd {
@@ -90,9 +97,11 @@ pub fn extract_command_info(cmd: &Commands) -> CommandInfo<'_> {
             command: "create",
             args,
         },
-        Commands::Motia { args } => CommandInfo::Dispatch {
-            command: "motia",
-            args,
+        Commands::Sdk(sdk_cmd) => match sdk_cmd {
+            SdkCommands::Motia { args } => CommandInfo::Dispatch {
+                command: "motia",
+                args,
+            },
         },
         Commands::Start { args } => CommandInfo::Dispatch {
             command: "start",

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,8 +234,13 @@ async fn handle_update(target: Option<&str>) -> i32 {
             vec![update::self_update(&client, &mut app_state).await]
         }
         Some(cmd) => {
+            // Normalize SDK-namespaced commands to registry keys
+            let registry_key = match cmd {
+                "sdk" => "motia-cli",
+                other => other,
+            };
             // Update specific binary
-            let spec = match registry::resolve_binary_for_update(cmd) {
+            let spec = match registry::resolve_binary_for_update(registry_key) {
                 Ok(s) => s,
                 Err(e) => {
                     eprintln!("{} {}", "error:".red(), e);
@@ -309,7 +314,13 @@ fn handle_list() -> i32 {
             .iter()
             .find(|s| s.name == name)
             .and_then(|s| s.commands.first())
-            .map(|c| c.cli_command)
+            .map(|c| {
+                if c.cli_command == "motia" {
+                    "sdk motia"
+                } else {
+                    c.cli_command
+                }
+            })
             .unwrap_or("?");
 
         eprintln!(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -65,7 +65,7 @@ pub static REGISTRY: &[BinarySpec] = &[
     BinarySpec {
         name: "iii-tools",
         repo: "iii-hq/cli-tooling",
-        has_checksum: false,
+        has_checksum: true,
         supported_targets: &[
             "aarch64-apple-darwin",
             "x86_64-apple-darwin",
@@ -159,11 +159,17 @@ pub fn all_binaries() -> Vec<&'static BinarySpec> {
     REGISTRY.iter().collect()
 }
 
-/// List all available CLI command names.
+/// List all available CLI command names (using user-facing paths).
 pub fn available_commands() -> Vec<&'static str> {
     REGISTRY
         .iter()
-        .flat_map(|spec| spec.commands.iter().map(|m| m.cli_command))
+        .flat_map(|spec| spec.commands.iter().map(|m| {
+            if m.cli_command == "motia" {
+                "sdk motia"
+            } else {
+                m.cli_command
+            }
+        }))
         .collect()
 }
 
@@ -234,14 +240,33 @@ mod tests {
         let cmds = available_commands();
         assert!(cmds.contains(&"console"));
         assert!(cmds.contains(&"create"));
-        assert!(cmds.contains(&"motia"));
+        assert!(cmds.contains(&"sdk motia"));
         assert!(cmds.contains(&"start"));
+        assert!(!cmds.contains(&"motia"), "motia should be namespaced as 'sdk motia'");
+    }
+
+    #[test]
+    fn test_resolve_binary_for_update_motia() {
+        let spec = resolve_binary_for_update("motia").unwrap();
+        assert_eq!(spec.name, "motia-cli");
+    }
+
+    #[test]
+    fn test_resolve_binary_for_update_sdk_not_in_registry() {
+        // "sdk" is not a valid registry key; the update command must translate it
+        assert!(resolve_binary_for_update("sdk").is_err());
     }
 
     #[test]
     fn test_console_has_checksum() {
         let (spec, _) = resolve_command("console").unwrap();
         assert!(spec.has_checksum);
+    }
+
+    #[test]
+    fn test_iii_tools_has_checksum() {
+        let (spec, _) = resolve_command("create").unwrap();
+        assert!(spec.has_checksum, "iii-tools should have checksums enabled");
     }
 
     #[test]


### PR DESCRIPTION
# chore: update installation script and CLI commands; bump version to 0.2.4

## Summary

Updates the iii-cli installation script with Homebrew conflict detection, restructures the CLI to namespace Motia under `sdk motia`, enables checksums for iii-tools, and bumps the version to 0.2.4.

### Key changes

- **Install script (`install.sh`)**:
  - Add `check_homebrew()` to detect when the binary is already installed via Homebrew and suggest `brew upgrade` or manual uninstall
  - Add `BREW_FORMULA` env var and `--force` flag to skip the Homebrew check
  - Improve version-already-installed message with install path and guidance when installing to a different directory
  - Update post-install hint: `iii-cli motia` → `iii-cli sdk motia`

- **CLI structure (`src/cli.rs`)**:
  - Move `motia` under a new `sdk` subcommand: `iii-cli sdk motia`
  - Remove hardcoded `after_help` text

- **Update/List commands (`src/main.rs`, `src/registry.rs`)**:
  - Normalize `sdk` to `motia-cli` when resolving binaries for update
  - Display `sdk motia` in list output instead of `motia`
  - Enable `has_checksum: true` for iii-tools

- **Version**: 0.2.3 → 0.2.4

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Comments added for complex logic where needed
- [x] No new warnings introduced
- [x] Tests added/updated (registry tests for new behavior)

## Additional Context

The `motia` command is now namespaced as `sdk motia` to align with future SDK-related subcommands. The install script now detects Homebrew-managed installations and guides users to use `brew upgrade` instead of overwriting with the script, reducing confusion and potential conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew conflict detection during installation with `--force` option to skip checks.
  * Introduced `sdk motia` command structure for accessing the CLI.

* **Improvements**
  * Enhanced installation messaging with clearer guidance for existing installations.
  * Updated branding references throughout to reflect `sdk motia` naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->